### PR TITLE
Feature/#49

### DIFF
--- a/app/Http/Controllers/Manager/Auth/LoginController.php
+++ b/app/Http/Controllers/Manager/Auth/LoginController.php
@@ -65,10 +65,10 @@ class LoginController extends Controller
     {
         $manager = Manager::Where('store_name',$request->store_name)
             ->where('password',$request->password)
-            ->where('withdraw_status', false)
             ->first();
-            // dd($manager);
         if($manager){
+            $manager->login_status = true;
+            $manager->save();
             Auth::guard('manager')->login($manager, true);
             if($manager->manager_id == 1){
                 return redirect()->route('manager_list');

--- a/app/Http/Controllers/Manager/ManagerController.php
+++ b/app/Http/Controllers/Manager/ManagerController.php
@@ -17,33 +17,26 @@ class ManagerController extends Controller
 {
 
     public function user_insert() {
-        if(Auth::guard('manager')->check() && Auth::guard('manager')->user()->withdraw_status == false) {
-            $user_id = sprintf("%06d",mt_rand(0,999999));
-            $pw = substr(str_shuffle('1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 8);
-            $dt = Carbon::now()->toDateString();
-            $manager_id = Auth::guard('manager')->user()->manager_id;
-            return view('manager.user_insert',[
-                "user_id" => $user_id,
-                "pw" => $pw,
-                "dt" => $dt,
-                "manager_id" => $manager_id
-            ]);
-        }else{
-            return redirect()->route('manager.loginpage');
-        }
+        $user_id = sprintf("%06d",mt_rand(0,999999));
+        $pw = substr(str_shuffle('1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 8);
+        $dt = Carbon::now()->toDateString();
+        $manager_id = Auth::guard('manager')->user()->manager_id;
+        return view('manager.user_insert',[
+            "user_id" => $user_id,
+            "pw" => $pw,
+            "dt" => $dt,
+            "manager_id" => $manager_id
+        ]);
+
     }
 
     public function detail($user_id) {
-        if(Auth::guard('manager')->check() && Auth::guard('manager')->user()->withdraw_status == false) {
-            $users = User::find($user_id);
-            $manager = Auth::guard('manager')->user();
-            return view('manager.user_detail',[
-                'users' => $users,
-                'manager' => $manager,
-            ]);
-        }else {
-            return redirect()->route('manager.loginpage');
-        }
+        $users = User::find($user_id);
+        $manager = Auth::guard('manager')->user();
+        return view('manager.user_detail',[
+            'users' => $users,
+            'manager' => $manager,
+        ]);
     }
 
     public function delete($user_id,$keyword = null) {
@@ -74,41 +67,36 @@ class ManagerController extends Controller
 
     public function userListSearch(Request $request)
     {
-        if(Auth::guard('manager')->check() && Auth::guard('manager')->user()->withdraw_status == false) {
-            //キーワード取得
-            $keyword = $request->input('keyword');          
-            // マネージャーIDを取得
-            $manager_id = Auth::guard('manager')->user()->manager_id;
-            
-            //キーワード入力されている場合
-            if(!empty($keyword))
-            {   
-                //  ユーザーから検索
-                $users = DB::table('users')
-                        ->where('user_id','like','%'.$keyword.'%')
-                        ->orwhere('name','like', '%'.$keyword.'%')
-                        ->orwhere('tel_number','like', '%'.$keyword.'%')
-                        ->where("manager_id",$manager_id)
-                        // データ降順表示
-                        ->latest()
-                        ->get();
+        //キーワード取得
+        $keyword = $request->input('keyword');          
+        // マネージャーIDを取得
+        $manager_id = Auth::guard('manager')->user()->manager_id;
+        
+        //キーワード入力されている場合
+        if(!empty($keyword))
+        {   
+            //  ユーザーから検索
+            $users = DB::table('users')
+                    ->where('user_id','like','%'.$keyword.'%')
+                    ->orwhere('name','like', '%'.$keyword.'%')
+                    ->orwhere('tel_number','like', '%'.$keyword.'%')
+                    ->where("manager_id",$manager_id)
+                    // データ降順表示
+                    ->latest()
+                    ->get();
 
-            }else{//キーワードが未入力の場合
-                $users = DB::table('users')
-                        ->where("manager_id",$manager_id)
-                        // データ降順表示
-                        ->latest()
-                        ->get();
-            }
-            //検索フォームへ
-            return view('manager/user_list',[
-                'users' => $users,
-                'keyword' => $keyword,
-                ]);
-                
-        }else {
-            return redirect()->route('manager.loginpage');
-        }    
+        }else{//キーワードが未入力の場合
+            $users = DB::table('users')
+                    ->where("manager_id",$manager_id)
+                    // データ降順表示
+                    ->latest()
+                    ->get();
+        }
+        //検索フォームへ
+        return view('manager/user_list',[
+            'users' => $users,
+            'keyword' => $keyword,
+        ]);
     }
     
     //  ユーザーデータ更新
@@ -124,17 +112,14 @@ class ManagerController extends Controller
     }
 
     public function editManagerForm($manager_id = null){
-        if(Auth::guard('manager')->check() && Auth::guard('manager')->user()->manager_id == 1) {
-            $manager = Manager::find($manager_id);
-            return view('manager.editManagerForm',['manager' => $manager]);
-        }else{
-            return redirect()->route('manager.loginpage');
-        }
+        $manager = Manager::find($manager_id);
+        return view('manager.editManagerForm',['manager' => $manager]);
     }
 
     public function storeEditManager(Request $request){
         $manager = Manager::find($request->manager_id);
-        $manager->withdraw_status = true;
+        $manager->edit_status = true;
+        $manager->login_status = false;
         $manager->fill($request->all())->save();
         return redirect()->route('manager_list');
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -57,5 +57,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'checkManager' => \App\Http\Middleware\CheckManager::class,
     ];
 }

--- a/app/Http/Middleware/CheckManager.php
+++ b/app/Http/Middleware/CheckManager.php
@@ -18,7 +18,7 @@ class CheckManager
     {
         if (!Auth::guard('manager')->check()) {
             return redirect()->route('manager.loginpage');
-        }else if(Auth::guard('manager')->user()->login_status == false){
+        }else if(Auth::guard('manager')->user()->login_status == 0){
             Auth::guard('manager')->logout();
             return redirect()->route('manager.loginpage');
         }

--- a/app/Http/Middleware/CheckManager.php
+++ b/app/Http/Middleware/CheckManager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class CheckManager
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (!Auth::guard('manager')->check()) {
+            return redirect()->route('manager.loginpage');
+        }else if(Auth::guard('manager')->user()->login_status == false){
+            Auth::guard('manager')->logout();
+            return redirect()->route('manager.loginpage');
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/Manager.php
+++ b/app/Models/Manager.php
@@ -19,6 +19,7 @@ class Manager extends Authenticatable
     protected $fillable = [
         'store_name',
         'password',
+        'edit_status',
     ];
     protected $hidden = [
         'password',

--- a/database/migrations/2019_12_08_165732_add_withdraw_to_manager_table.php
+++ b/database/migrations/2019_12_08_165732_add_withdraw_to_manager_table.php
@@ -15,6 +15,7 @@ class AddWithdrawToManagerTable extends Migration
     {
         Schema::table('manager', function (Blueprint $table) {
             $table->boolean('edit_status')->default(false);
+            $table->boolean('login_status')->default(true);
         });
     }
 

--- a/database/migrations/2019_12_08_165732_add_withdraw_to_manager_table.php
+++ b/database/migrations/2019_12_08_165732_add_withdraw_to_manager_table.php
@@ -14,7 +14,7 @@ class AddWithdrawToManagerTable extends Migration
     public function up()
     {
         Schema::table('manager', function (Blueprint $table) {
-            $table->boolean('withdraw_status')->default(false);
+            $table->boolean('edit_status')->default(false);
         });
     }
 

--- a/resources/views/manager/editManagerForm.blade.php
+++ b/resources/views/manager/editManagerForm.blade.php
@@ -40,7 +40,7 @@
                 {{-- ログインボタン --}}
                 <div class="flexArea">
                     <input type="hidden" name="manager_id" value="{{$manager->manager_id}}">
-                    <input class="sendButton" type="submit" value="退会させる" style="margin-top:25px" />
+                    <input class="sendButton" type="submit" value="編集を確定" style="margin-top:25px" />
                     <a href="{{route('manager_list')}}"class="sendButton" style="margin-top:25px">戻る</a>
                 </div>
             </form>

--- a/resources/views/manager/manager_list.blade.php
+++ b/resources/views/manager/manager_list.blade.php
@@ -13,8 +13,8 @@
                         <tr>
                             <th class="column">店舗名</th>
                             <th class="column">password</th>
+                            <th class="link">編集</th>
                             <th class="link">削除</th>
-                            <th class="link">退会</th>
                         </tr>
                     </thead>
                     @if (count($managers))
@@ -24,14 +24,16 @@
                                     <tr class="record">
                                         <th score="row">{{$manager->store_name}}</th>
                                         <td>{{$manager->password}}</td>
-                                        <td><a class ="lineHeight fontRed" href="{{ '/manager/delete_manager'.'/'.$manager->manager_id }}">削除</a></td>
                                         <td>
-                                            @if($manager->withdraw_status) 
-                                            <p class ="lineHeight fontRed">退会済</p>
+                                            <a href="{{route('edit.manager.form',$manager->manager_id)}}" class ="lineHeight fontWhite">
+                                            @if($manager->edit_status) 
+                                            編集済
                                             @else
-                                            <a href="{{route('edit.manager.form',$manager->manager_id)}}" class ="lineHeight fontRed">退会</a>
+                                            編集
                                             @endif
+                                            </a>
                                         </td>
+                                        <td><a class ="lineHeight fontRed" href="{{ '/manager/delete_manager'.'/'.$manager->manager_id }}">削除</a></td>
                                     </tr> 
                                 @endif
                             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,34 +41,36 @@ Route::post('/manager/login', 'Manager\Auth\LoginController@login')->name('manag
 
 Route::get('/manager/logout', 'Manager\Auth\LoginController@logout')->name('manager.logout');
 
-// 店舗登録
-Route::get('/manager/managerCreateForm','Manager\SignupController@managerCreateForm')->name('manager.createForm');
-Route::post('/manager/managerCreate','Manager\SignupController@managerCreate')->name('manager.create');
+Route::group(['middleware'=>'checkManager'],function(){
+    // 店舗登録
+    Route::get('/manager/managerCreateForm','Manager\SignupController@managerCreateForm')->name('manager.createForm');
+    Route::post('/manager/managerCreate','Manager\SignupController@managerCreate')->name('manager.create');
 
-// 店舗編集
-Route::get('manager/edit_manager/form/{id?}','Manager\ManagerController@editManagerForm')->name('edit.manager.form');
-Route::post('manager/edit_manager','Manager\ManagerController@storeEditManager')->name('store.edit.manager');
+    // 店舗編集
+    Route::get('manager/edit_manager/form/{id?}','Manager\ManagerController@editManagerForm')->name('edit.manager.form');
+    Route::post('manager/edit_manager','Manager\ManagerController@storeEditManager')->name('store.edit.manager');
 
-// 店舗一覧
-Route::get('manager/manager_list','Manager\ManagerController@managerList')->name('manager_list');
+    // 店舗一覧
+    Route::get('manager/manager_list','Manager\ManagerController@managerList')->name('manager_list');
 
-// 店舗削除
-Route::get('/manager/delete_manager/{manager_id}','Manager\ManagerController@deleteManager')->name('manager_delete');
+    // 店舗削除
+    Route::get('/manager/delete_manager/{manager_id}','Manager\ManagerController@deleteManager')->name('manager_delete');
 
-// 新規登録処理
-Route::post('/sign_up', 'Manager\SignupController@userCreate')->name('user.create');
+    // 新規登録処理
+    Route::post('/sign_up', 'Manager\SignupController@userCreate')->name('user.create');
 
-// 管理者表示画面
-Route::get('/manager/user_insert', 'Manager\ManagerController@user_insert')->name('user_insert');
+    // 管理者表示画面
+    Route::get('/manager/user_insert', 'Manager\ManagerController@user_insert')->name('user_insert');
 
-// ユーザ一覧画面
-Route::get('/manager/user_list','Manager\ManagerController@userListSearch')->name('user_list');
+    // ユーザ一覧画面
+    Route::get('/manager/user_list','Manager\ManagerController@userListSearch')->name('user_list');
 
-// ユーザ詳細画面
-Route::get('/manager/user_detail/{user_id}','Manager\ManagerController@detail')->name('user_detail');
+    // ユーザ詳細画面
+    Route::get('/manager/user_detail/{user_id}','Manager\ManagerController@detail')->name('user_detail');
 
-// ユーザ削除
-Route::get('/manager/delete/{user_id?}/{keyword?}','Manager\ManagerController@delete')->name('user_delete');
+    // ユーザ削除
+    Route::get('/manager/delete/{user_id?}/{keyword?}','Manager\ManagerController@delete')->name('user_delete');
 
-// ユーザー更新
-Route::post('/user/update','Manager\ManagerController@userUpdate')->name('userUpdate');
+    // ユーザー更新
+    Route::post('/user/update','Manager\ManagerController@userUpdate')->name('userUpdate');
+});


### PR DESCRIPTION
# 
### 対応内容
###### 退会機能ではなく、編集機能に変更、カラム名の変更、追加。
withdraw_status->edit_status, add login_status  
 - 処理の流れとしては、管理者が店舗のパスワードを編集した時に、login_status,edit_statusがそれぞれ入力される。
 - login_statusが0の場合には、その店舗はログアウトさせる。
 - 新しいパスワードでログインした時に、login_statusを1に戻す
###### Auth::checkをmiddlewareで管理
# 
### レビュー担当者に特に確認してもらいたいこと
管理者をchrome店舗をsafariとか違うブラウザで確認しないと、Auth関連が上書きされてしまうの注意。
管理者が店舗のパスを編集した時に、店舗は強制的にログアウトさせられるか
# 
### 対象Issue
#49 
# 
### 参考URL

# 
### その他・備考
ミドルウェア追加しているので、composer dump-autoloadをした方が良いかもしれないです。
あと、php artisan migrate::refresh 